### PR TITLE
Add back-to-top to index template (fixes #3)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,5 +26,8 @@
     </li>
     {{ end }}
   </ul>
+  <div class="pagination tc db fixed-l bottom-2-l right-2-l mb3 mb0-l">
+    {{ partial "back-to-top.html" . }}
+  </div>
 </main>
 {{ partial "tag_cloud.html" . }} {{ partial "pagination.html" . }} {{ end }}


### PR DESCRIPTION
After this change, back to top button shows up on the homepage. It was already enabled and showing correctly for tag/category/archive pages. Can delete branch after merge, if all OK.